### PR TITLE
feat: add auditing base classes and custom JPA naming strategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <url/>
     </scm>
     <properties>
-        <java.version>21</java.version>
+        <java.version>24</java.version>
     </properties>
     <dependencies>
         <dependency>
@@ -41,6 +41,28 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -64,6 +86,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.encryptorcode</groupId>
+            <artifactId>pluralize</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/innospace/platform/shared/domain/model/aggregates/AuditableAbstractAggregateRoot.java
+++ b/src/main/java/com/innospace/platform/shared/domain/model/aggregates/AuditableAbstractAggregateRoot.java
@@ -1,0 +1,40 @@
+package com.innospace.platform.shared.domain.model.aggregates;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.AbstractAggregateRoot;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.Date;
+
+/**
+ * Base class for all aggregate roots that require auditing.
+ *
+ * @param <T> the type of the aggregate root
+ */
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditableAbstractAggregateRoot<T extends AbstractAggregateRoot<T>> extends AbstractAggregateRoot<T> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Date createdAt;
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Date updatedAt;
+
+    /**
+     * Registers a domain event.
+     *
+     * @param event the domain event to register
+     */
+    public void addDomainEvent(Object event) {
+        super.registerEvent(event);
+    }
+}

--- a/src/main/java/com/innospace/platform/shared/domain/model/entities/AuditableModel.java
+++ b/src/main/java/com/innospace/platform/shared/domain/model/entities/AuditableModel.java
@@ -1,0 +1,29 @@
+package com.innospace.platform.shared.domain.model.entities;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.Date;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditableModel {
+    @Id
+    @Getter
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Getter
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Date createdAt;
+
+    @Getter
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Date updatedAt;
+}

--- a/src/main/java/com/innospace/platform/shared/infrastructure/persistence/jpa/configuration/strategy/SnakeCaseWithPluralizedTablePhysicalNamingStrategy.java
+++ b/src/main/java/com/innospace/platform/shared/infrastructure/persistence/jpa/configuration/strategy/SnakeCaseWithPluralizedTablePhysicalNamingStrategy.java
@@ -1,0 +1,67 @@
+package com.innospace.platform.shared.infrastructure.persistence.jpa.configuration.strategy;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import static io.github.encryptorcode.pluralize.Pluralize.pluralize;
+
+/**
+ * Snake Case With Pluralized Table Physical Naming Strategy
+ * @summary
+ * PhysicalNamingStrategy implementation that converts entity names to snake_case and table names to pluralized snake_case.
+ *
+ * @since 1.0.0
+ */
+public class SnakeCaseWithPluralizedTablePhysicalNamingStrategy implements PhysicalNamingStrategy {
+    @Override
+    public Identifier toPhysicalCatalogName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return null;
+    }
+
+    @Override
+    public Identifier toPhysicalSchemaName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(identifier);
+    }
+
+    @Override
+    public Identifier toPhysicalTableName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(this.toPlural(identifier));
+    }
+
+    @Override
+    public Identifier toPhysicalSequenceName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(identifier);
+    }
+
+    @Override
+    public Identifier toPhysicalColumnName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(identifier);
+    }
+
+    /**
+     * Convert identifier to snake case
+     * @param identifier Identifier
+     * @return Identifier
+     */
+    private Identifier toSnakeCase(final Identifier identifier) {
+        if (identifier == null) {
+            return null;
+        }
+        final String regex = "([a-z])([A-Z])";
+        final String replacement = "$1_$2";
+        final String newName = identifier.getText()
+                .replaceAll(regex, replacement)
+                .toLowerCase();
+        return Identifier.toIdentifier(newName);
+    }
+
+    /**
+     * Convert identifier to plural
+     * @param identifier Identifier
+     * @return Identifier
+     */
+    private Identifier toPlural(final Identifier identifier) {
+        final String newName = pluralize(identifier.getText());
+        return Identifier.toIdentifier(newName);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,29 @@
-spring.application.name=innospace-platform
+
+# Spring Application Name
+spring.application.name=InnoSpace Platform
+
+# Spring DataSource Configuration
+spring.datasource.url=jdbc:mysql://localhost:3306/innospace?useSSL=false&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=password
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Spring Data JPA Configuration
+spring.jpa.show-sql=true
+
+#Spring Data JPA Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.naming.physical-strategy=com.innospace.platform.shared.infrastructure.persistence.jpa.configuration.strategy.SnakeCaseWithPluralizedTablePhysicalNamingStrategy
+
+# Application Information for Documentation
+
+# Elements take their values from maven pom.xml build-related information
+documentation.application.description=@project.description@
+documentation.application.version=@project.version@
+
+# JWT Configuration Properties
+authorization.jwt.secret = WriteHereYourSecretStringForTokenSigningCredentials
+authorization.jwt.expiration.days = 7
+


### PR DESCRIPTION
Introduced AuditableAbstractAggregateRoot and AuditableModel for entity auditing support. Updated pom.xml with dependencies for pluralization, JWT, and OpenAPI, set Java version to 24, and enhanced application.properties with datasource, JPA, JWT, and documentation settings.