### PR TITLE
feate: add manager and student profile domain and REST API

### DIFF
--- a/src/main/java/com/innospace/platform/InnospacePlatformApplication.java
+++ b/src/main/java/com/innospace/platform/InnospacePlatformApplication.java
@@ -1,9 +1,12 @@
 package com.innospace.platform;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class InnospacePlatformApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/innospace/platform/profiles/application/application/internal/commandservices/ManagerProfileCommandServiceImpl.java
+++ b/src/main/java/com/innospace/platform/profiles/application/application/internal/commandservices/ManagerProfileCommandServiceImpl.java
@@ -1,0 +1,39 @@
+package com.innospace.platform.profiles.application.application.internal.commandservices;
+
+
+import com.innospace.platform.profiles.domain.aggregates.ManagerProfile;
+import com.innospace.platform.profiles.domain.commands.CreateManagerProfileCommand;
+import com.innospace.platform.profiles.domain.commands.UpdateManagerProfileCommand;
+import com.innospace.platform.profiles.domain.services.ManagerProfileCommandService;
+import com.innospace.platform.profiles.infrastructure.persistence.jpa.repositories.ManagerProfileRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class ManagerProfileCommandServiceImpl implements ManagerProfileCommandService {
+
+    private final ManagerProfileRepository managerProfileRepository;
+
+    public ManagerProfileCommandServiceImpl(ManagerProfileRepository managerProfileRepository) {
+        this.managerProfileRepository = managerProfileRepository;
+    }
+
+    @Override
+    public Optional<ManagerProfile> handle(CreateManagerProfileCommand command) {
+        var profile = new ManagerProfile(command);
+        return Optional.of(managerProfileRepository.save(profile));
+    }
+
+    @Override
+    public Optional<ManagerProfile> handle(UpdateManagerProfileCommand command) {
+        var existing = managerProfileRepository.findById(command.profileId());
+        if (existing.isEmpty()) return Optional.empty();
+
+        var profile = existing.get();
+        profile.updateProfile(command); // Método en el aggregate
+        return Optional.of(managerProfileRepository.save(profile));
+    }
+
+
+}

--- a/src/main/java/com/innospace/platform/profiles/application/application/internal/commandservices/StudentProfileCommandServiceImpl.java
+++ b/src/main/java/com/innospace/platform/profiles/application/application/internal/commandservices/StudentProfileCommandServiceImpl.java
@@ -1,0 +1,40 @@
+package com.innospace.platform.profiles.application.application.internal.commandservices;
+
+
+import com.innospace.platform.profiles.domain.aggregates.StudentProfile;
+import com.innospace.platform.profiles.domain.commands.CreateStudentProfileCommand;
+import com.innospace.platform.profiles.domain.commands.UpdateStudentProfileCommand;
+import com.innospace.platform.profiles.domain.services.StudentProfileCommandService;
+import com.innospace.platform.profiles.infrastructure.persistence.jpa.repositories.StudentProfileRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class StudentProfileCommandServiceImpl implements StudentProfileCommandService {
+
+    private final StudentProfileRepository studentProfileRepository;
+
+    public StudentProfileCommandServiceImpl(StudentProfileRepository studentProfileRepository) {
+        this.studentProfileRepository = studentProfileRepository;
+    }
+
+    @Override
+    public Optional<StudentProfile> handle(CreateStudentProfileCommand command) {
+        // Basic: create and save
+        var profile = new StudentProfile(command);
+        return Optional.of(studentProfileRepository.save(profile));
+    }
+
+    @Override
+    public Optional<StudentProfile> handle(UpdateStudentProfileCommand command) {
+        var existing = studentProfileRepository.findById(command.profileId());
+        if (existing.isEmpty()) return Optional.empty();
+
+        var profile = existing.get();
+        profile.updateProfile(command);
+        return Optional.of(studentProfileRepository.save(profile));
+    }
+
+
+}

--- a/src/main/java/com/innospace/platform/profiles/application/application/internal/queryservices/ManagerProfileQueryServiceImpl.java
+++ b/src/main/java/com/innospace/platform/profiles/application/application/internal/queryservices/ManagerProfileQueryServiceImpl.java
@@ -1,0 +1,44 @@
+package com.innospace.platform.profiles.application.application.internal.queryservices;
+
+
+import com.innospace.platform.profiles.domain.aggregates.ManagerProfile;
+import com.innospace.platform.profiles.domain.queries.GetAllManagerProfilesQuery;
+import com.innospace.platform.profiles.domain.queries.GetManagerProfileByEmailQuery;
+import com.innospace.platform.profiles.domain.queries.GetManagerProfileByIdQuery;
+import com.innospace.platform.profiles.domain.queries.GetManagerProfileByUserIdQuery;
+import com.innospace.platform.profiles.domain.services.ManagerProfileQueryService;
+import com.innospace.platform.profiles.infrastructure.persistence.jpa.repositories.ManagerProfileRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ManagerProfileQueryServiceImpl implements ManagerProfileQueryService {
+
+    private final ManagerProfileRepository managerProfileRepository;
+
+    public ManagerProfileQueryServiceImpl(ManagerProfileRepository managerProfileRepository) {
+        this.managerProfileRepository = managerProfileRepository;
+    }
+
+    @Override
+    public Optional<ManagerProfile> handle(GetManagerProfileByIdQuery query) {
+        return managerProfileRepository.findById(query.profileId());
+    }
+
+    @Override
+    public Optional<ManagerProfile> handle(GetManagerProfileByEmailQuery query) {
+        return managerProfileRepository.findByEmail(query.email());
+    }
+
+    @Override
+    public List<ManagerProfile> handle(GetAllManagerProfilesQuery query) {
+        return managerProfileRepository.findAll();
+    }
+    @Override
+    public Optional<ManagerProfile> handle(GetManagerProfileByUserIdQuery query) {
+        return managerProfileRepository.findByUserId(query.userId());
+    }
+
+}

--- a/src/main/java/com/innospace/platform/profiles/application/application/internal/queryservices/StudentProfileQueryServiceImpl.java
+++ b/src/main/java/com/innospace/platform/profiles/application/application/internal/queryservices/StudentProfileQueryServiceImpl.java
@@ -1,0 +1,44 @@
+package com.innospace.platform.profiles.application.application.internal.queryservices;
+
+
+import com.innospace.platform.profiles.domain.aggregates.StudentProfile;
+import com.innospace.platform.profiles.domain.queries.GetAllStudentProfilesQuery;
+import com.innospace.platform.profiles.domain.queries.GetStudentProfileByEmailQuery;
+import com.innospace.platform.profiles.domain.queries.GetStudentProfileByIdQuery;
+import com.innospace.platform.profiles.domain.queries.GetStudentProfileByUserIdQuery;
+import com.innospace.platform.profiles.domain.services.StudentProfileQueryService;
+import com.innospace.platform.profiles.infrastructure.persistence.jpa.repositories.StudentProfileRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class StudentProfileQueryServiceImpl implements StudentProfileQueryService {
+
+    private final StudentProfileRepository studentProfileRepository;
+
+    public StudentProfileQueryServiceImpl(StudentProfileRepository studentProfileRepository) {
+        this.studentProfileRepository = studentProfileRepository;
+    }
+
+    @Override
+    public Optional<StudentProfile> handle(GetStudentProfileByIdQuery query) {
+        return studentProfileRepository.findById(query.profileId());
+    }
+
+    @Override
+    public Optional<StudentProfile> handle(GetStudentProfileByEmailQuery query) {
+        return studentProfileRepository.findByEmail(query.email());
+    }
+
+    @Override
+    public List<StudentProfile> handle(GetAllStudentProfilesQuery query) {
+        return studentProfileRepository.findAll();
+    }
+    @Override
+    public Optional<StudentProfile> handle(GetStudentProfileByUserIdQuery query) {
+        return studentProfileRepository.findByUserId(query.userId());
+    }
+
+}

--- a/src/main/java/com/innospace/platform/profiles/domain/aggregates/ManagerProfile.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/aggregates/ManagerProfile.java
@@ -1,0 +1,62 @@
+package com.innospace.platform.profiles.domain.aggregates;
+
+
+import com.innospace.platform.profiles.domain.commands.CreateManagerProfileCommand;
+import com.innospace.platform.profiles.domain.commands.UpdateManagerProfileCommand;
+import com.innospace.platform.shared.domain.model.aggregates.AuditableAbstractAggregateRoot;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Entity
+@Table(name = "manager_profiles")
+@NoArgsConstructor
+public class ManagerProfile extends AuditableAbstractAggregateRoot<ManagerProfile> {
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String photoUrl;
+
+    private String companyName;
+    private String focusArea;
+
+    @ElementCollection
+    @CollectionTable(name = "manager_company_technologies", joinColumns = @JoinColumn(name = "manager_id"))
+    @Column(name = "technology")
+    private Set<String> companyTechnologies = new HashSet<>();
+
+    public ManagerProfile(CreateManagerProfileCommand command) {
+        this.userId = command.userId();
+        this.name = command.name();
+        this.email = command.email();
+        this.photoUrl = command.photoUrl();
+        this.companyName = command.companyName();
+        this.focusArea = command.focusArea();
+        if (command.companyTechnologies() != null) this.companyTechnologies.addAll(command.companyTechnologies());
+    }
+
+    public void updateProfile(UpdateManagerProfileCommand cmd) {
+        this.name = cmd.name();
+        this.photoUrl = cmd.photoUrl();
+        this.companyName = cmd.companyName();
+        this.focusArea = cmd.focusArea();
+        if (cmd.companyTechnologies() != null) {
+            this.companyTechnologies.clear();
+            this.companyTechnologies.addAll(cmd.companyTechnologies());
+        }
+    }
+
+    public void addCompanyTechnology(String tech) { this.companyTechnologies.add(tech); }
+    public void removeCompanyTechnology(String tech) { this.companyTechnologies.remove(tech); }
+}

--- a/src/main/java/com/innospace/platform/profiles/domain/aggregates/StudentProfile.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/aggregates/StudentProfile.java
@@ -1,0 +1,79 @@
+package com.innospace.platform.profiles.domain.aggregates;
+
+
+import com.innospace.platform.profiles.domain.commands.CreateStudentProfileCommand;
+import com.innospace.platform.profiles.domain.commands.UpdateStudentProfileCommand;
+import com.innospace.platform.shared.domain.model.aggregates.AuditableAbstractAggregateRoot;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Entity
+@Table(name = "student_profiles")
+@NoArgsConstructor
+public class StudentProfile extends AuditableAbstractAggregateRoot<StudentProfile> {
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String photoUrl;
+
+    @ElementCollection
+    @CollectionTable(name = "student_skills", joinColumns = @JoinColumn(name = "student_id"))
+    @Column(name = "skill")
+    private Set<String> skills = new HashSet<>();
+
+    @ElementCollection
+    @CollectionTable(name = "student_education", joinColumns = @JoinColumn(name = "student_id"))
+    @Column(name = "education_entry")
+    private Set<String> education = new HashSet<>();
+
+    @ElementCollection
+    @CollectionTable(name = "student_experiences", joinColumns = @JoinColumn(name = "student_id"))
+    @Column(name = "experience_entry")
+    private Set<String> experiences = new HashSet<>();
+
+
+
+    public StudentProfile(CreateStudentProfileCommand command) {
+        this.userId = command.userId();
+        this.name = command.name();
+        this.email = command.email();
+        this.photoUrl = command.photoUrl();
+        if (command.skills() != null) this.skills.addAll(command.skills());
+        if (command.education() != null) this.education.addAll(command.education());
+        if (command.experiences() != null) this.experiences.addAll(command.experiences());
+    }
+
+
+    public void updateProfile(UpdateStudentProfileCommand cmd) {
+        this.name = cmd.name();
+        this.photoUrl = cmd.photoUrl();
+        if (cmd.skills() != null) {
+            this.skills.clear();
+            this.skills.addAll(cmd.skills());
+        }
+        if (cmd.education() != null) {
+            this.education.clear();
+            this.education.addAll(cmd.education());
+        }
+        if (cmd.experiences() != null) {
+            this.experiences.clear();
+            this.experiences.addAll(cmd.experiences());
+        }
+    }
+
+    public void addSkill(String skill) { this.skills.add(skill); }
+    public void removeSkill(String skill) { this.skills.remove(skill); }
+    public void addExperience(String experience) { this.experiences.add(experience); }
+}

--- a/src/main/java/com/innospace/platform/profiles/domain/commands/CreateManagerProfileCommand.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/commands/CreateManagerProfileCommand.java
@@ -1,0 +1,13 @@
+package com.innospace.platform.profiles.domain.commands;
+
+import java.util.Set;
+
+public record CreateManagerProfileCommand(
+        Long userId,
+        String name,
+        String email,
+        String photoUrl,
+        String companyName,
+        String focusArea,
+        Set<String> companyTechnologies
+) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/commands/CreateStudentProfileCommand.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/commands/CreateStudentProfileCommand.java
@@ -1,0 +1,13 @@
+package com.innospace.platform.profiles.domain.commands;
+
+import java.util.Set;
+
+public record CreateStudentProfileCommand(
+        Long userId,
+        String name,
+        String email,
+        String photoUrl,
+        Set<String> skills,
+        Set<String> education,
+        Set<String> experiences
+) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/commands/UpdateManagerProfileCommand.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/commands/UpdateManagerProfileCommand.java
@@ -1,0 +1,12 @@
+package com.innospace.platform.profiles.domain.commands;
+
+import java.util.Set;
+
+public record UpdateManagerProfileCommand(
+        Long profileId,
+        String name,
+        String photoUrl,
+        String companyName,
+        String focusArea,
+        Set<String> companyTechnologies
+) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/commands/UpdateStudentProfileCommand.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/commands/UpdateStudentProfileCommand.java
@@ -1,0 +1,12 @@
+package com.innospace.platform.profiles.domain.commands;
+
+import java.util.Set;
+
+public record UpdateStudentProfileCommand(
+        Long profileId,
+        String name,
+        String photoUrl,
+        Set<String> skills,
+        Set<String> education,
+        Set<String> experiences
+) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/queries/GetAllManagerProfilesQuery.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/queries/GetAllManagerProfilesQuery.java
@@ -1,0 +1,4 @@
+package com.innospace.platform.profiles.domain.queries;
+
+public record GetAllManagerProfilesQuery() {
+}

--- a/src/main/java/com/innospace/platform/profiles/domain/queries/GetAllStudentProfilesQuery.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/queries/GetAllStudentProfilesQuery.java
@@ -1,0 +1,4 @@
+package com.innospace.platform.profiles.domain.queries;
+
+public record GetAllStudentProfilesQuery() {
+}

--- a/src/main/java/com/innospace/platform/profiles/domain/queries/GetManagerProfileByEmailQuery.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/queries/GetManagerProfileByEmailQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.profiles.domain.queries;
+
+public record GetManagerProfileByEmailQuery(String email) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/queries/GetManagerProfileByIdQuery.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/queries/GetManagerProfileByIdQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.profiles.domain.queries;
+
+public record GetManagerProfileByIdQuery(Long profileId) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/queries/GetManagerProfileByUserIdQuery.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/queries/GetManagerProfileByUserIdQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.profiles.domain.queries;
+
+public record GetManagerProfileByUserIdQuery(Long userId) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/queries/GetStudentProfileByEmailQuery.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/queries/GetStudentProfileByEmailQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.profiles.domain.queries;
+
+public record GetStudentProfileByEmailQuery(String email) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/queries/GetStudentProfileByIdQuery.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/queries/GetStudentProfileByIdQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.profiles.domain.queries;
+
+public record GetStudentProfileByIdQuery(Long profileId) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/queries/GetStudentProfileByUserIdQuery.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/queries/GetStudentProfileByUserIdQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.profiles.domain.queries;
+
+public record GetStudentProfileByUserIdQuery(Long userId) {}

--- a/src/main/java/com/innospace/platform/profiles/domain/services/ManagerProfileCommandService.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/services/ManagerProfileCommandService.java
@@ -1,0 +1,12 @@
+package com.innospace.platform.profiles.domain.services;
+
+import com.innospace.platform.profiles.domain.aggregates.ManagerProfile;
+import com.innospace.platform.profiles.domain.commands.CreateManagerProfileCommand;
+import com.innospace.platform.profiles.domain.commands.UpdateManagerProfileCommand;
+
+import java.util.Optional;
+
+public interface ManagerProfileCommandService {
+    Optional<ManagerProfile> handle(CreateManagerProfileCommand command);
+    Optional<ManagerProfile> handle(UpdateManagerProfileCommand command);
+}

--- a/src/main/java/com/innospace/platform/profiles/domain/services/ManagerProfileQueryService.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/services/ManagerProfileQueryService.java
@@ -1,0 +1,18 @@
+package com.innospace.platform.profiles.domain.services;
+
+import com.innospace.platform.profiles.domain.aggregates.ManagerProfile;
+import com.innospace.platform.profiles.domain.queries.GetAllManagerProfilesQuery;
+import com.innospace.platform.profiles.domain.queries.GetManagerProfileByEmailQuery;
+import com.innospace.platform.profiles.domain.queries.GetManagerProfileByIdQuery;
+import com.innospace.platform.profiles.domain.queries.GetManagerProfileByUserIdQuery;
+
+import java.util.List;
+import java.util.Optional;
+
+
+public interface ManagerProfileQueryService {
+    Optional<ManagerProfile> handle(GetManagerProfileByIdQuery query);
+    Optional<ManagerProfile> handle(GetManagerProfileByUserIdQuery query);
+    Optional<ManagerProfile> handle(GetManagerProfileByEmailQuery query);
+    List<ManagerProfile> handle(GetAllManagerProfilesQuery query);
+}

--- a/src/main/java/com/innospace/platform/profiles/domain/services/StudentProfileCommandService.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/services/StudentProfileCommandService.java
@@ -1,0 +1,12 @@
+package com.innospace.platform.profiles.domain.services;
+
+import com.innospace.platform.profiles.domain.aggregates.StudentProfile;
+import com.innospace.platform.profiles.domain.commands.CreateStudentProfileCommand;
+import com.innospace.platform.profiles.domain.commands.UpdateStudentProfileCommand;
+
+import java.util.Optional;
+
+public interface StudentProfileCommandService {
+    Optional<StudentProfile> handle(CreateStudentProfileCommand command);
+    Optional<StudentProfile> handle(UpdateStudentProfileCommand command);
+}

--- a/src/main/java/com/innospace/platform/profiles/domain/services/StudentProfileQueryService.java
+++ b/src/main/java/com/innospace/platform/profiles/domain/services/StudentProfileQueryService.java
@@ -1,0 +1,17 @@
+package com.innospace.platform.profiles.domain.services;
+
+import com.innospace.platform.profiles.domain.aggregates.StudentProfile;
+import com.innospace.platform.profiles.domain.queries.GetAllStudentProfilesQuery;
+import com.innospace.platform.profiles.domain.queries.GetStudentProfileByEmailQuery;
+import com.innospace.platform.profiles.domain.queries.GetStudentProfileByIdQuery;
+import com.innospace.platform.profiles.domain.queries.GetStudentProfileByUserIdQuery;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudentProfileQueryService {
+    Optional<StudentProfile> handle(GetStudentProfileByIdQuery query);
+    Optional<StudentProfile> handle(GetStudentProfileByUserIdQuery query);
+    Optional<StudentProfile> handle(GetStudentProfileByEmailQuery query);
+    List<StudentProfile> handle(GetAllStudentProfilesQuery query);
+}

--- a/src/main/java/com/innospace/platform/profiles/infrastructure/persistence/jpa/repositories/ManagerProfileRepository.java
+++ b/src/main/java/com/innospace/platform/profiles/infrastructure/persistence/jpa/repositories/ManagerProfileRepository.java
@@ -1,0 +1,11 @@
+package com.innospace.platform.profiles.infrastructure.persistence.jpa.repositories;
+
+import com.innospace.platform.profiles.domain.aggregates.ManagerProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ManagerProfileRepository extends JpaRepository<ManagerProfile, Long> {
+    Optional<ManagerProfile> findByEmail(String email);
+    Optional<ManagerProfile> findByUserId(Long userId);
+}

--- a/src/main/java/com/innospace/platform/profiles/infrastructure/persistence/jpa/repositories/StudentProfileRepository.java
+++ b/src/main/java/com/innospace/platform/profiles/infrastructure/persistence/jpa/repositories/StudentProfileRepository.java
@@ -1,0 +1,11 @@
+package com.innospace.platform.profiles.infrastructure.persistence.jpa.repositories;
+
+import com.innospace.platform.profiles.domain.aggregates.StudentProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StudentProfileRepository extends JpaRepository<StudentProfile, Long> {
+    Optional<StudentProfile> findByEmail(String email);
+    Optional<StudentProfile> findByUserId(Long userId);
+}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/ManagerProfilesController.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/ManagerProfilesController.java
@@ -1,0 +1,70 @@
+package com.innospace.platform.profiles.interfaces.rest;
+
+import com.innospace.platform.profiles.domain.queries.GetAllManagerProfilesQuery;
+import com.innospace.platform.profiles.domain.queries.GetManagerProfileByIdQuery;
+import com.innospace.platform.profiles.domain.services.ManagerProfileCommandService;
+import com.innospace.platform.profiles.domain.services.ManagerProfileQueryService;
+import com.innospace.platform.profiles.interfaces.rest.assemblers.CreateManagerProfileCommandFromResourceAssembler;
+import com.innospace.platform.profiles.interfaces.rest.assemblers.ManagerProfileResourceFromEntityAssembler;
+import com.innospace.platform.profiles.interfaces.rest.resources.CreateManagerProfileResource;
+import com.innospace.platform.profiles.interfaces.rest.resources.ManagerProfileResource;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/api/v1/manager-profiles", produces = MediaType.APPLICATION_JSON_VALUE)
+@Tag(name = "Manager Profiles", description = "Available Manager Profile Endpoints")
+public class ManagerProfilesController {
+
+    private final ManagerProfileCommandService managerProfileCommandService;
+    private final ManagerProfileQueryService managerProfileQueryService;
+
+    public ManagerProfilesController(ManagerProfileCommandService managerProfileCommandService,
+                                     ManagerProfileQueryService managerProfileQueryService) {
+        this.managerProfileCommandService = managerProfileCommandService;
+        this.managerProfileQueryService = managerProfileQueryService;
+    }
+
+    @PostMapping
+    @Operation(summary = "Create a new manager profile")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Manager profile created"),
+            @ApiResponse(responseCode = "400", description = "Bad request")})
+    public ResponseEntity<ManagerProfileResource> createManagerProfile(@RequestBody CreateManagerProfileResource resource) {
+        var command = CreateManagerProfileCommandFromResourceAssembler.toCommandFromResource(resource);
+        var profile = managerProfileCommandService.handle(command);
+        if (profile.isEmpty()) return ResponseEntity.badRequest().build();
+        var createdProfile = profile.get();
+        var resourceResponse = ManagerProfileResourceFromEntityAssembler.toResourceFromEntity(createdProfile);
+        return new ResponseEntity<>(resourceResponse, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{profileId}")
+    @Operation(summary = "Get a manager profile by ID")
+    public ResponseEntity<ManagerProfileResource> getManagerProfileById(@PathVariable Long profileId) {
+        var query = new GetManagerProfileByIdQuery(profileId);
+        var profile = managerProfileQueryService.handle(query);
+        if (profile.isEmpty()) return ResponseEntity.notFound().build();
+        var resourceResponse = ManagerProfileResourceFromEntityAssembler.toResourceFromEntity(profile.get());
+        return ResponseEntity.ok(resourceResponse);
+    }
+
+    @GetMapping
+    @Operation(summary = "Get all manager profiles")
+    public ResponseEntity<List<ManagerProfileResource>> getAllManagerProfiles() {
+        var profiles = managerProfileQueryService.handle(new GetAllManagerProfilesQuery());
+        if (profiles.isEmpty()) return ResponseEntity.notFound().build();
+        var resources = profiles.stream()
+                .map(ManagerProfileResourceFromEntityAssembler::toResourceFromEntity)
+                .toList();
+        return ResponseEntity.ok(resources);
+    }
+}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/StudentProfilesController.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/StudentProfilesController.java
@@ -1,0 +1,70 @@
+package com.innospace.platform.profiles.interfaces.rest;
+
+import com.innospace.platform.profiles.domain.queries.GetAllStudentProfilesQuery;
+import com.innospace.platform.profiles.domain.queries.GetStudentProfileByIdQuery;
+import com.innospace.platform.profiles.domain.services.StudentProfileCommandService;
+import com.innospace.platform.profiles.domain.services.StudentProfileQueryService;
+import com.innospace.platform.profiles.interfaces.rest.assemblers.CreateStudentProfileCommandFromResourceAssembler;
+import com.innospace.platform.profiles.interfaces.rest.assemblers.StudentProfileResourceFromEntityAssembler;
+import com.innospace.platform.profiles.interfaces.rest.resources.CreateStudentProfileResource;
+import com.innospace.platform.profiles.interfaces.rest.resources.StudentProfileResource;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/api/v1/student-profiles", produces = MediaType.APPLICATION_JSON_VALUE)
+@Tag(name = "Student Profiles", description = "Available Student Profile Endpoints")
+public class StudentProfilesController {
+
+    private final StudentProfileCommandService studentProfileCommandService;
+    private final StudentProfileQueryService studentProfileQueryService;
+
+    public StudentProfilesController(StudentProfileCommandService studentProfileCommandService,
+                                     StudentProfileQueryService studentProfileQueryService) {
+        this.studentProfileCommandService = studentProfileCommandService;
+        this.studentProfileQueryService = studentProfileQueryService;
+    }
+
+    @PostMapping
+    @Operation(summary = "Create a new student profile")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Student profile created"),
+            @ApiResponse(responseCode = "400", description = "Bad request")})
+    public ResponseEntity<StudentProfileResource> createStudentProfile(@RequestBody CreateStudentProfileResource resource) {
+        var command = CreateStudentProfileCommandFromResourceAssembler.toCommandFromResource(resource);
+        var profile = studentProfileCommandService.handle(command);
+        if (profile.isEmpty()) return ResponseEntity.badRequest().build();
+        var createdProfile = profile.get();
+        var resourceResponse = StudentProfileResourceFromEntityAssembler.toResourceFromEntity(createdProfile);
+        return new ResponseEntity<>(resourceResponse, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{profileId}")
+    @Operation(summary = "Get a student profile by ID")
+    public ResponseEntity<StudentProfileResource> getStudentProfileById(@PathVariable Long profileId) {
+        var query = new GetStudentProfileByIdQuery(profileId);
+        var profile = studentProfileQueryService.handle(query);
+        if (profile.isEmpty()) return ResponseEntity.notFound().build();
+        var resourceResponse = StudentProfileResourceFromEntityAssembler.toResourceFromEntity(profile.get());
+        return ResponseEntity.ok(resourceResponse);
+    }
+
+    @GetMapping
+    @Operation(summary = "Get all student profiles")
+    public ResponseEntity<List<StudentProfileResource>> getAllStudentProfiles() {
+        var profiles = studentProfileQueryService.handle(new GetAllStudentProfilesQuery());
+        if (profiles.isEmpty()) return ResponseEntity.notFound().build();
+        var resources = profiles.stream()
+                .map(StudentProfileResourceFromEntityAssembler::toResourceFromEntity)
+                .toList();
+        return ResponseEntity.ok(resources);
+    }
+}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/assemblers/CreateManagerProfileCommandFromResourceAssembler.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/assemblers/CreateManagerProfileCommandFromResourceAssembler.java
@@ -1,0 +1,18 @@
+package com.innospace.platform.profiles.interfaces.rest.assemblers;
+
+import com.innospace.platform.profiles.domain.commands.CreateManagerProfileCommand;
+import com.innospace.platform.profiles.interfaces.rest.resources.CreateManagerProfileResource;
+
+public class CreateManagerProfileCommandFromResourceAssembler {
+    public static CreateManagerProfileCommand toCommandFromResource(CreateManagerProfileResource resource) {
+        return new CreateManagerProfileCommand(
+                resource.userId(),
+                resource.name(),
+                resource.email(),
+                resource.photoUrl(),
+                resource.companyName(),
+                resource.focusArea(),
+                resource.companyTechnologies()
+        );
+    }
+}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/assemblers/CreateStudentProfileCommandFromResourceAssembler.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/assemblers/CreateStudentProfileCommandFromResourceAssembler.java
@@ -1,0 +1,18 @@
+package com.innospace.platform.profiles.interfaces.rest.assemblers;
+
+import com.innospace.platform.profiles.domain.commands.CreateStudentProfileCommand;
+import com.innospace.platform.profiles.interfaces.rest.resources.CreateStudentProfileResource;
+
+public class CreateStudentProfileCommandFromResourceAssembler {
+    public static CreateStudentProfileCommand toCommandFromResource(CreateStudentProfileResource resource) {
+        return new CreateStudentProfileCommand(
+                resource.userId(),
+                resource.name(),
+                resource.email(),
+                resource.photoUrl(),
+                resource.skills(),
+                resource.education(),
+                resource.experiences()
+        );
+    }
+}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/assemblers/ManagerProfileResourceFromEntityAssembler.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/assemblers/ManagerProfileResourceFromEntityAssembler.java
@@ -1,0 +1,19 @@
+package com.innospace.platform.profiles.interfaces.rest.assemblers;
+
+import com.innospace.platform.profiles.domain.aggregates.ManagerProfile;
+import com.innospace.platform.profiles.interfaces.rest.resources.ManagerProfileResource;
+
+public class ManagerProfileResourceFromEntityAssembler {
+    public static ManagerProfileResource toResourceFromEntity(ManagerProfile entity) {
+        return new ManagerProfileResource(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getName(),
+                entity.getEmail(),
+                entity.getPhotoUrl(),
+                entity.getCompanyName(),
+                entity.getFocusArea(),
+                entity.getCompanyTechnologies()
+        );
+    }
+}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/assemblers/StudentProfileResourceFromEntityAssembler.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/assemblers/StudentProfileResourceFromEntityAssembler.java
@@ -1,0 +1,19 @@
+package com.innospace.platform.profiles.interfaces.rest.assemblers;
+
+import com.innospace.platform.profiles.domain.aggregates.StudentProfile;
+import com.innospace.platform.profiles.interfaces.rest.resources.StudentProfileResource;
+
+public class StudentProfileResourceFromEntityAssembler {
+    public static StudentProfileResource toResourceFromEntity(StudentProfile entity) {
+        return new StudentProfileResource(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getName(),
+                entity.getEmail(),
+                entity.getPhotoUrl(),
+                entity.getSkills(),
+                entity.getEducation(),
+                entity.getExperiences()
+        );
+    }
+}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/resources/CreateManagerProfileResource.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/resources/CreateManagerProfileResource.java
@@ -1,0 +1,13 @@
+package com.innospace.platform.profiles.interfaces.rest.resources;
+
+import java.util.Set;
+
+public record CreateManagerProfileResource(
+        Long userId,
+        String name,
+        String email,
+        String photoUrl,
+        String companyName,
+        String focusArea,
+        Set<String> companyTechnologies
+) {}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/resources/CreateStudentProfileResource.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/resources/CreateStudentProfileResource.java
@@ -1,0 +1,14 @@
+package com.innospace.platform.profiles.interfaces.rest.resources;
+
+import java.util.List;
+import java.util.Set;
+
+public record CreateStudentProfileResource(
+        Long userId,
+        String name,
+        String email,
+        String photoUrl,
+        Set<String> skills,
+        Set<String> education,
+        Set<String> experiences
+) {}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/resources/ManagerProfileResource.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/resources/ManagerProfileResource.java
@@ -1,0 +1,14 @@
+package com.innospace.platform.profiles.interfaces.rest.resources;
+
+import java.util.Set;
+
+public record ManagerProfileResource(
+        Long id,
+        Long userId,
+        String name,
+        String email,
+        String photoUrl,
+        String companyName,
+        String focusArea,
+        Set<String> companyTechnologies
+) {}

--- a/src/main/java/com/innospace/platform/profiles/interfaces/rest/resources/StudentProfileResource.java
+++ b/src/main/java/com/innospace/platform/profiles/interfaces/rest/resources/StudentProfileResource.java
@@ -1,0 +1,15 @@
+package com.innospace.platform.profiles.interfaces.rest.resources;
+
+import java.util.List;
+import java.util.Set;
+
+public record StudentProfileResource(
+        Long id,
+        Long userId,
+        String name,
+        String email,
+        String photoUrl,
+        Set<String> skills,
+        Set<String> education,
+        Set<String> experiences
+) {}

--- a/src/main/java/com/innospace/platform/shared/domain/model/aggregates/AuditableAbstractAggregateRoot.java
+++ b/src/main/java/com/innospace/platform/shared/domain/model/aggregates/AuditableAbstractAggregateRoot.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.domain.AbstractAggregateRoot;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+
 import java.util.Date;
 
 /**
@@ -28,6 +29,7 @@ public class AuditableAbstractAggregateRoot<T extends AbstractAggregateRoot<T>> 
     @LastModifiedDate
     @Column(nullable = false)
     private Date updatedAt;
+
 
     /**
      * Registers a domain event.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,9 @@
 spring.application.name=InnoSpace Platform
 
 # Spring DataSource Configuration
-spring.datasource.url=jdbc:mysql://localhost:3306/innospace?useSSL=false&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://localhost:3306/innospacedb?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=password
+spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Spring Data JPA Configuration
@@ -19,11 +19,4 @@ spring.jpa.hibernate.naming.physical-strategy=com.innospace.platform.shared.infr
 
 # Application Information for Documentation
 
-# Elements take their values from maven pom.xml build-related information
-documentation.application.description=@project.description@
-documentation.application.version=@project.version@
-
-# JWT Configuration Properties
-authorization.jwt.secret = WriteHereYourSecretStringForTokenSigningCredentials
-authorization.jwt.expiration.days = 7
 


### PR DESCRIPTION
Introduces domain models, commands, queries, services, repositories, and REST controllers for manager and student profiles. Enables creation, retrieval, and listing of profiles, with JPA auditing support and updated datasource configuration.