### PR TITLE
feat: add queries for all entities

### DIFF
--- a/src/main/java/com/innospace/platform/companyopportunities/application/internal/queryservices/OpportunityQueryServiceImpl.java
+++ b/src/main/java/com/innospace/platform/companyopportunities/application/internal/queryservices/OpportunityQueryServiceImpl.java
@@ -2,7 +2,8 @@ package com.innospace.platform.companyopportunities.application.internal.queryse
 
 
 import com.innospace.platform.companyopportunities.domain.model.aggregates.Opportunity;
-import com.innospace.platform.companyopportunities.domain.model.queries.GetAllCompanyOpportunitiesQuery;
+import com.innospace.platform.companyopportunities.domain.model.queries.GetAllCompanyOpportunitiesByCompanyIdQuery;
+import com.innospace.platform.companyopportunities.domain.model.queries.GetAllOpportunitiesQuery;
 import com.innospace.platform.companyopportunities.domain.model.queries.GetOpportunityByIdQuery;
 import com.innospace.platform.companyopportunities.domain.model.queries.ValidateOpportunityOwnershipQuery;
 import com.innospace.platform.companyopportunities.domain.services.OpportunityQueryService;
@@ -27,7 +28,11 @@ public class OpportunityQueryServiceImpl implements OpportunityQueryService {
     }
 
     @Override
-    public List<Opportunity> handle(GetAllCompanyOpportunitiesQuery query) {
+    public List<Opportunity> handle(GetAllOpportunitiesQuery query) {
+        return opportunityRepository.findAll();
+    }
+    @Override
+    public List<Opportunity> handle(GetAllCompanyOpportunitiesByCompanyIdQuery query) {
         return opportunityRepository.findAllByCompanyId(query.companyId());
     }
 

--- a/src/main/java/com/innospace/platform/companyopportunities/domain/model/queries/GetAllCompanyOpportunitiesByCompanyIdQuery.java
+++ b/src/main/java/com/innospace/platform/companyopportunities/domain/model/queries/GetAllCompanyOpportunitiesByCompanyIdQuery.java
@@ -1,3 +1,3 @@
 package com.innospace.platform.companyopportunities.domain.model.queries;
 
-public record GetAllCompanyOpportunitiesQuery(Long companyId) {}
+public record GetAllCompanyOpportunitiesByCompanyIdQuery(Long companyId) {}

--- a/src/main/java/com/innospace/platform/companyopportunities/domain/model/queries/GetAllOpportunitiesQuery.java
+++ b/src/main/java/com/innospace/platform/companyopportunities/domain/model/queries/GetAllOpportunitiesQuery.java
@@ -1,0 +1,4 @@
+package com.innospace.platform.companyopportunities.domain.model.queries;
+
+public record GetAllOpportunitiesQuery() {
+}

--- a/src/main/java/com/innospace/platform/companyopportunities/domain/services/OpportunityQueryService.java
+++ b/src/main/java/com/innospace/platform/companyopportunities/domain/services/OpportunityQueryService.java
@@ -2,7 +2,8 @@ package com.innospace.platform.companyopportunities.domain.services;
 
 
 import com.innospace.platform.companyopportunities.domain.model.aggregates.Opportunity;
-import com.innospace.platform.companyopportunities.domain.model.queries.GetAllCompanyOpportunitiesQuery;
+import com.innospace.platform.companyopportunities.domain.model.queries.GetAllCompanyOpportunitiesByCompanyIdQuery;
+import com.innospace.platform.companyopportunities.domain.model.queries.GetAllOpportunitiesQuery;
 import com.innospace.platform.companyopportunities.domain.model.queries.GetOpportunityByIdQuery;
 import com.innospace.platform.companyopportunities.domain.model.queries.ValidateOpportunityOwnershipQuery;
 
@@ -12,6 +13,7 @@ import java.util.Optional;
 public interface OpportunityQueryService {
 
     Optional<Opportunity> handle(GetOpportunityByIdQuery query);
-    List<Opportunity> handle(GetAllCompanyOpportunitiesQuery query);
+    List<Opportunity> handle(GetAllCompanyOpportunitiesByCompanyIdQuery query);
     boolean handle(ValidateOpportunityOwnershipQuery query);
+    List<Opportunity> handle(GetAllOpportunitiesQuery query);
 }

--- a/src/main/java/com/innospace/platform/companyopportunities/interfaces/rest/OpportunityController.java
+++ b/src/main/java/com/innospace/platform/companyopportunities/interfaces/rest/OpportunityController.java
@@ -4,7 +4,8 @@ package com.innospace.platform.companyopportunities.interfaces.rest;
 import com.innospace.platform.companyopportunities.domain.model.commands.CloseOpportunityCommand;
 import com.innospace.platform.companyopportunities.domain.model.commands.DeleteOpportunityCommand;
 import com.innospace.platform.companyopportunities.domain.model.commands.PublishOpportunityCommand;
-import com.innospace.platform.companyopportunities.domain.model.queries.GetAllCompanyOpportunitiesQuery;
+import com.innospace.platform.companyopportunities.domain.model.queries.GetAllCompanyOpportunitiesByCompanyIdQuery;
+import com.innospace.platform.companyopportunities.domain.model.queries.GetAllOpportunitiesQuery;
 import com.innospace.platform.companyopportunities.domain.model.queries.GetOpportunityByIdQuery;
 import com.innospace.platform.companyopportunities.domain.services.OpportunityCommandService;
 import com.innospace.platform.companyopportunities.domain.services.OpportunityQueryService;
@@ -14,6 +15,7 @@ import com.innospace.platform.companyopportunities.interfaces.rest.resources.Upd
 import com.innospace.platform.companyopportunities.interfaces.rest.transform.CreateOpportunityCommandFromResourceAssembler;
 import com.innospace.platform.companyopportunities.interfaces.rest.transform.OpportunityResourceFromEntityAssembler;
 import com.innospace.platform.companyopportunities.interfaces.rest.transform.UpdateOpportunityCommandFromResourceAssembler;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,7 +47,7 @@ public class OpportunityController {
 
     @GetMapping("/company/{companyId}")
     public List<OpportunityResource> getAllCompanyOpportunities(@PathVariable Long companyId) {
-        var query = new GetAllCompanyOpportunitiesQuery(companyId);
+        var query = new GetAllCompanyOpportunitiesByCompanyIdQuery(companyId);
         return queryService.handle(query)
                 .stream()
                 .map(OpportunityResourceFromEntityAssembler::toResourceFromEntity)
@@ -96,5 +98,16 @@ public class OpportunityController {
     public ResponseEntity<Void> deleteOpportunity(@PathVariable Long id) {
         commandService.handle(new DeleteOpportunityCommand(id));
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    @Operation(summary = "Get all opportunities")
+    public ResponseEntity<List<OpportunityResource>> getAllOpportunities() {
+        var opportunities = queryService.handle(new GetAllOpportunitiesQuery());
+        if (opportunities.isEmpty()) return ResponseEntity.notFound().build();
+        var resources = opportunities.stream()
+                .map(OpportunityResourceFromEntityAssembler::toResourceFromEntity)
+                .toList();
+        return ResponseEntity.ok(resources);
     }
 }

--- a/src/main/java/com/innospace/platform/studentprojects/application/internal/queryservices/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/innospace/platform/studentprojects/application/internal/queryservices/ProjectQueryServiceImpl.java
@@ -2,7 +2,8 @@ package com.innospace.platform.studentprojects.application.internal.queryservice
 
 
 import com.innospace.platform.studentprojects.domain.model.aggregates.Project;
-import com.innospace.platform.studentprojects.domain.model.queries.GetAllStudentProjectsQuery;
+import com.innospace.platform.studentprojects.domain.model.queries.GetAllProjectsQuery;
+import com.innospace.platform.studentprojects.domain.model.queries.GetAllStudentProjectsByIdQuery;
 import com.innospace.platform.studentprojects.domain.model.queries.GetProjectByIdQuery;
 import com.innospace.platform.studentprojects.domain.model.queries.ValidateProjectOwnershipQuery;
 import com.innospace.platform.studentprojects.domain.services.ProjectQueryService;
@@ -27,8 +28,12 @@ public class ProjectQueryServiceImpl implements ProjectQueryService {
     }
 
     @Override
-    public List<Project> handle(GetAllStudentProjectsQuery query) {
+    public List<Project> handle(GetAllStudentProjectsByIdQuery query) {
         return projectRepository.findAllByStudentId(query.studentId());
+    }
+    @Override
+    public List<Project> handle(GetAllProjectsQuery query) {
+        return projectRepository.findAll();
     }
 
     @Override

--- a/src/main/java/com/innospace/platform/studentprojects/domain/model/queries/GetAllProjectsQuery.java
+++ b/src/main/java/com/innospace/platform/studentprojects/domain/model/queries/GetAllProjectsQuery.java
@@ -1,0 +1,4 @@
+package com.innospace.platform.studentprojects.domain.model.queries;
+
+public record GetAllProjectsQuery() {
+}

--- a/src/main/java/com/innospace/platform/studentprojects/domain/model/queries/GetAllStudentProjectsByIdQuery.java
+++ b/src/main/java/com/innospace/platform/studentprojects/domain/model/queries/GetAllStudentProjectsByIdQuery.java
@@ -1,3 +1,3 @@
 package com.innospace.platform.studentprojects.domain.model.queries;
 
-public record GetAllStudentProjectsQuery(Long studentId) {}
+public record GetAllStudentProjectsByIdQuery(Long studentId) {}

--- a/src/main/java/com/innospace/platform/studentprojects/domain/services/ProjectQueryService.java
+++ b/src/main/java/com/innospace/platform/studentprojects/domain/services/ProjectQueryService.java
@@ -1,7 +1,8 @@
 package com.innospace.platform.studentprojects.domain.services;
 
 import com.innospace.platform.studentprojects.domain.model.aggregates.Project;
-import com.innospace.platform.studentprojects.domain.model.queries.GetAllStudentProjectsQuery;
+import com.innospace.platform.studentprojects.domain.model.queries.GetAllProjectsQuery;
+import com.innospace.platform.studentprojects.domain.model.queries.GetAllStudentProjectsByIdQuery;
 import com.innospace.platform.studentprojects.domain.model.queries.GetProjectByIdQuery;
 import com.innospace.platform.studentprojects.domain.model.queries.ValidateProjectOwnershipQuery;
 
@@ -12,7 +13,8 @@ public interface ProjectQueryService {
 
     Optional<Project> handle(GetProjectByIdQuery query);
 
-    List<Project> handle(GetAllStudentProjectsQuery query);
+    List<Project> handle(GetAllStudentProjectsByIdQuery query);
 
     boolean handle(ValidateProjectOwnershipQuery query);
+    List<Project> handle(GetAllProjectsQuery query);
 }

--- a/src/main/java/com/innospace/platform/studentprojects/interfaces/rest/ProjectController.java
+++ b/src/main/java/com/innospace/platform/studentprojects/interfaces/rest/ProjectController.java
@@ -6,9 +6,9 @@ import com.innospace.platform.studentprojects.application.internal.queryservices
 import com.innospace.platform.studentprojects.domain.model.commands.DeleteProjectCommand;
 import com.innospace.platform.studentprojects.domain.model.commands.FinalizeProjectCommand;
 import com.innospace.platform.studentprojects.domain.model.commands.PublishProjectCommand;
-import com.innospace.platform.studentprojects.domain.model.queries.GetAllStudentProjectsQuery;
+import com.innospace.platform.studentprojects.domain.model.queries.GetAllProjectsQuery;
+import com.innospace.platform.studentprojects.domain.model.queries.GetAllStudentProjectsByIdQuery;
 import com.innospace.platform.studentprojects.domain.model.queries.GetProjectByIdQuery;
-import com.innospace.platform.studentprojects.domain.services.ProjectQueryService;
 import com.innospace.platform.studentprojects.interfaces.rest.resources.CreateProjectResource;
 import com.innospace.platform.studentprojects.interfaces.rest.resources.ProjectResource;
 import com.innospace.platform.studentprojects.interfaces.rest.resources.UpdateProjectResource;
@@ -38,6 +38,18 @@ public class ProjectController {
     }
 
 
+    @GetMapping
+    @Operation(summary = "Get all projects")
+    public ResponseEntity<List<ProjectResource>> getAllProjects() {
+        var projects = projectQueryService.handle(new GetAllProjectsQuery());
+        if (projects.isEmpty()) return ResponseEntity.notFound().build();
+        var resources = projects.stream()
+                .map(ProjectResourceFromEntityAssembler::toResource)
+                .toList();
+        return ResponseEntity.ok(resources);
+    }
+
+
     @GetMapping("/{id}")
     @Operation(summary = "Get a project by ID")
     public ResponseEntity<ProjectResource> getProjectById(@PathVariable Long id) {
@@ -52,7 +64,7 @@ public class ProjectController {
     @GetMapping("/student/{studentId}")
     @Operation(summary = "Get projects by student ID")
     public ResponseEntity<List<ProjectResource>> getAllStudentProjects(@PathVariable Long studentId) {
-        var query = new GetAllStudentProjectsQuery(studentId);
+        var query = new GetAllStudentProjectsByIdQuery(studentId);
         var projects = projectQueryService.handle(query)
                 .stream()
                 .map(ProjectResourceFromEntityAssembler::toResource)


### PR DESCRIPTION
Introduced GetAllOpportunitiesQuery and GetAllProjectsQuery for retrieving all opportunities and projects, respectively. Added GetAllCompanyOpportunitiesByCompanyIdQuery and GetAllStudentProjectsByIdQuery for filtered queries by company and student. Updated service interfaces, implementations, and controllers to use the new queries and endpoints, improving clarity and separation between all-entity and filtered queries.