### PR TITLE
feat: add student application domain and REST API

### DIFF
--- a/src/main/java/com/innospace/platform/projectcollaboration/domain/model/services/CollaborationCardQueryService.java
+++ b/src/main/java/com/innospace/platform/projectcollaboration/domain/model/services/CollaborationCardQueryService.java
@@ -33,7 +33,6 @@ public class CollaborationCardQueryService {
     public List<CollaborationCardResource> getCardsByProject(Long projectId) {
         var collaborations = collaborationRepository.findAllByProjectId(projectId);
 
-        // Carga masiva de IDs para evitar N+1 queries
         var projectIds = collaborations.stream()
                 .map(CollaborationRequest::getProjectId)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/innospace/platform/studentapplications/application/internal/services/StudentApplicationCardQueryService.java
+++ b/src/main/java/com/innospace/platform/studentapplications/application/internal/services/StudentApplicationCardQueryService.java
@@ -1,0 +1,52 @@
+package com.innospace.platform.studentapplications.application.internal.services;
+
+import com.innospace.platform.companyopportunities.infrastructure.persistence.jpa.repositories.OpportunityRepository;
+import com.innospace.platform.profiles.infrastructure.persistence.jpa.repositories.StudentProfileRepository;
+import com.innospace.platform.studentapplications.infrastructure.jpa.repositories.StudentApplicationRepository;
+import com.innospace.platform.studentapplications.interfaces.rest.resources.StudentApplicationCardResource;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class StudentApplicationCardQueryService {
+
+    private final StudentApplicationRepository repository;
+    private final OpportunityRepository opportunityRepository;
+    private final StudentProfileRepository studentRepository;
+
+    public StudentApplicationCardQueryService(
+            StudentApplicationRepository repository,
+            OpportunityRepository opportunityRepository,
+            StudentProfileRepository studentRepository
+    ) {
+        this.repository = repository;
+        this.opportunityRepository = opportunityRepository;
+        this.studentRepository = studentRepository;
+    }
+
+    public List<StudentApplicationCardResource> getApplicationsByOpportunity(Long opportunityId) {
+        var applications = repository.findAllByOpportunityId(opportunityId);
+
+        return applications.stream()
+                .map(app -> {
+                    var opp = opportunityRepository.findById(app.getOpportunityId()).orElse(null);
+                    var student = studentRepository.findById(app.getStudentId()).orElse(null);
+                    if (opp == null || student == null) return null;
+
+                    return new StudentApplicationCardResource(
+                            app.getId(),
+                            opp.getId(),
+                            opp.getTitle(),
+                            opp.getDescription(),
+                            student.getId(),
+                            student.getName(),
+                            student.getPhotoUrl(),
+                            app.getManagerResponse().name()
+                    );
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+}

--- a/src/main/java/com/innospace/platform/studentapplications/application/internal/services/StudentApplicationCommandServiceImpl.java
+++ b/src/main/java/com/innospace/platform/studentapplications/application/internal/services/StudentApplicationCommandServiceImpl.java
@@ -1,0 +1,43 @@
+package com.innospace.platform.studentapplications.application.internal.services;
+
+import com.innospace.platform.studentapplications.domain.model.aggregates.StudentApplication;
+import com.innospace.platform.studentapplications.domain.model.commands.AcceptStudentApplicationCommand;
+import com.innospace.platform.studentapplications.domain.model.commands.CreateStudentApplicationCommand;
+import com.innospace.platform.studentapplications.domain.model.commands.RejectStudentApplicationCommand;
+import com.innospace.platform.studentapplications.domain.model.services.StudentApplicationCommandService;
+import com.innospace.platform.studentapplications.infrastructure.jpa.repositories.StudentApplicationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class StudentApplicationCommandServiceImpl implements StudentApplicationCommandService {
+
+    private final StudentApplicationRepository repository;
+
+    public StudentApplicationCommandServiceImpl(StudentApplicationRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Optional<StudentApplication> handle(CreateStudentApplicationCommand command) {
+        var application = new StudentApplication(command.opportunityId(), command.studentId());
+        return Optional.of(repository.save(application));
+    }
+
+    @Override
+    public Optional<StudentApplication> handle(AcceptStudentApplicationCommand command) {
+        var app = repository.findById(command.applicationId());
+        if (app.isEmpty()) return Optional.empty();
+        app.get().accept();
+        return Optional.of(repository.save(app.get()));
+    }
+
+    @Override
+    public Optional<StudentApplication> handle(RejectStudentApplicationCommand command) {
+        var app = repository.findById(command.applicationId());
+        if (app.isEmpty()) return Optional.empty();
+        app.get().reject();
+        return Optional.of(repository.save(app.get()));
+    }
+}

--- a/src/main/java/com/innospace/platform/studentapplications/application/internal/services/StudentApplicationQueryServiceImpl.java
+++ b/src/main/java/com/innospace/platform/studentapplications/application/internal/services/StudentApplicationQueryServiceImpl.java
@@ -1,0 +1,37 @@
+package com.innospace.platform.studentapplications.application.internal.services;
+
+import com.innospace.platform.studentapplications.domain.model.aggregates.StudentApplication;
+import com.innospace.platform.studentapplications.domain.model.queries.GetStudentApplicationByIdQuery;
+import com.innospace.platform.studentapplications.domain.model.queries.GetStudentApplicationsByOpportunityIdQuery;
+import com.innospace.platform.studentapplications.domain.model.queries.GetStudentApplicationsByStudentIdQuery;
+import com.innospace.platform.studentapplications.domain.model.services.StudentApplicationQueryService;
+import com.innospace.platform.studentapplications.infrastructure.jpa.repositories.StudentApplicationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class StudentApplicationQueryServiceImpl implements StudentApplicationQueryService {
+
+    private final StudentApplicationRepository repository;
+
+    public StudentApplicationQueryServiceImpl(StudentApplicationRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<StudentApplication> handle(GetStudentApplicationsByOpportunityIdQuery query) {
+        return repository.findAllByOpportunityId(query.opportunityId());
+    }
+
+    @Override
+    public List<StudentApplication> handle(GetStudentApplicationsByStudentIdQuery query) {
+        return repository.findAllByStudentId(query.studentId());
+    }
+
+    @Override
+    public Optional<StudentApplication> handle(GetStudentApplicationByIdQuery query) {
+        return repository.findById(query.applicationId());
+    }
+}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/aggregates/StudentApplication.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/aggregates/StudentApplication.java
@@ -1,0 +1,47 @@
+package com.innospace.platform.studentapplications.domain.model.aggregates;
+
+
+import com.innospace.platform.shared.domain.model.aggregates.AuditableAbstractAggregateRoot;
+import com.innospace.platform.studentapplications.domain.model.valueobjects.ApplicationStatus;
+import com.innospace.platform.studentapplications.domain.model.valueobjects.ManagerResponseStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "student_applications", uniqueConstraints = @UniqueConstraint(columnNames = {"opportunity_id", "student_id"}))
+public class StudentApplication extends AuditableAbstractAggregateRoot<StudentApplication> {
+
+    @Column(name = "opportunity_id", nullable = false)
+    private Long opportunityId;
+
+    @Column(name = "student_id", nullable = false)
+    private Long studentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ApplicationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ManagerResponseStatus managerResponse;
+
+    protected StudentApplication() {}
+
+    public StudentApplication(Long opportunityId, Long studentId) {
+        this.opportunityId = opportunityId;
+        this.studentId = studentId;
+        this.status = ApplicationStatus.PENDING;
+        this.managerResponse = ManagerResponseStatus.PENDING;
+    }
+
+    public void accept() {
+        this.managerResponse = ManagerResponseStatus.ACCEPTED;
+        this.status = ApplicationStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        this.managerResponse = ManagerResponseStatus.REJECTED;
+        this.status = ApplicationStatus.REJECTED;
+    }
+}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/commands/AcceptStudentApplicationCommand.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/commands/AcceptStudentApplicationCommand.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.studentapplications.domain.model.commands;
+
+public record AcceptStudentApplicationCommand(Long applicationId) {}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/commands/CreateStudentApplicationCommand.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/commands/CreateStudentApplicationCommand.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.studentapplications.domain.model.commands;
+
+public record CreateStudentApplicationCommand(Long opportunityId, Long studentId) {}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/commands/RejectStudentApplicationCommand.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/commands/RejectStudentApplicationCommand.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.studentapplications.domain.model.commands;
+
+public record RejectStudentApplicationCommand(Long applicationId) {}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/queries/GetStudentApplicationByIdQuery.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/queries/GetStudentApplicationByIdQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.studentapplications.domain.model.queries;
+
+public record GetStudentApplicationByIdQuery(Long applicationId) {}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/queries/GetStudentApplicationsByOpportunityIdQuery.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/queries/GetStudentApplicationsByOpportunityIdQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.studentapplications.domain.model.queries;
+
+public record GetStudentApplicationsByOpportunityIdQuery(Long opportunityId) {}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/queries/GetStudentApplicationsByStudentIdQuery.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/queries/GetStudentApplicationsByStudentIdQuery.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.studentapplications.domain.model.queries;
+
+public record GetStudentApplicationsByStudentIdQuery(Long studentId) {}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/services/StudentApplicationCommandService.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/services/StudentApplicationCommandService.java
@@ -1,0 +1,14 @@
+package com.innospace.platform.studentapplications.domain.model.services;
+
+import com.innospace.platform.studentapplications.domain.model.aggregates.StudentApplication;
+import com.innospace.platform.studentapplications.domain.model.commands.AcceptStudentApplicationCommand;
+import com.innospace.platform.studentapplications.domain.model.commands.CreateStudentApplicationCommand;
+import com.innospace.platform.studentapplications.domain.model.commands.RejectStudentApplicationCommand;
+
+import java.util.Optional;
+
+public interface StudentApplicationCommandService {
+    Optional<StudentApplication> handle(CreateStudentApplicationCommand command);
+    Optional<StudentApplication> handle(AcceptStudentApplicationCommand command);
+    Optional<StudentApplication> handle(RejectStudentApplicationCommand command);
+}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/services/StudentApplicationQueryService.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/services/StudentApplicationQueryService.java
@@ -1,0 +1,15 @@
+package com.innospace.platform.studentapplications.domain.model.services;
+
+import com.innospace.platform.studentapplications.domain.model.aggregates.StudentApplication;
+import com.innospace.platform.studentapplications.domain.model.queries.GetStudentApplicationByIdQuery;
+import com.innospace.platform.studentapplications.domain.model.queries.GetStudentApplicationsByOpportunityIdQuery;
+import com.innospace.platform.studentapplications.domain.model.queries.GetStudentApplicationsByStudentIdQuery;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudentApplicationQueryService {
+    List<StudentApplication> handle(GetStudentApplicationsByOpportunityIdQuery query);
+    List<StudentApplication> handle(GetStudentApplicationsByStudentIdQuery query);
+    Optional<StudentApplication> handle(GetStudentApplicationByIdQuery query);
+}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/valueobjects/ApplicationStatus.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/valueobjects/ApplicationStatus.java
@@ -1,0 +1,5 @@
+package com.innospace.platform.studentapplications.domain.model.valueobjects;
+
+public enum ApplicationStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/innospace/platform/studentapplications/domain/model/valueobjects/ManagerResponseStatus.java
+++ b/src/main/java/com/innospace/platform/studentapplications/domain/model/valueobjects/ManagerResponseStatus.java
@@ -1,0 +1,5 @@
+package com.innospace.platform.studentapplications.domain.model.valueobjects;
+
+public enum ManagerResponseStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/innospace/platform/studentapplications/infrastructure/jpa/repositories/StudentApplicationRepository.java
+++ b/src/main/java/com/innospace/platform/studentapplications/infrastructure/jpa/repositories/StudentApplicationRepository.java
@@ -1,0 +1,13 @@
+package com.innospace.platform.studentapplications.infrastructure.jpa.repositories;
+
+import com.innospace.platform.studentapplications.domain.model.aggregates.StudentApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface StudentApplicationRepository extends JpaRepository<StudentApplication, Long> {
+    List<StudentApplication> findAllByOpportunityId(Long opportunityId);
+    List<StudentApplication> findAllByStudentId(Long studentId);
+}

--- a/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/StudentApplicationCardController.java
+++ b/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/StudentApplicationCardController.java
@@ -1,0 +1,31 @@
+package com.innospace.platform.studentapplications.interfaces.rest;
+
+import com.innospace.platform.studentapplications.application.internal.services.StudentApplicationCardQueryService;
+import com.innospace.platform.studentapplications.interfaces.rest.resources.StudentApplicationCardResource;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/opportunity-cards")
+@Tag(name = "Student Application Cards", description = "Endpoints for viewing student applications cards")
+public class StudentApplicationCardController {
+
+    private final StudentApplicationCardQueryService queryService;
+
+    public StudentApplicationCardController(StudentApplicationCardQueryService queryService) {
+        this.queryService = queryService;
+    }
+
+    @GetMapping("/opportunities/{opportunityId}")
+    public ResponseEntity<List<StudentApplicationCardResource>> getApplicationCards(@PathVariable Long opportunityId) {
+        var cards = queryService.getApplicationsByOpportunity(opportunityId);
+        if (cards.isEmpty()) return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(cards);
+    }
+}

--- a/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/StudentApplicationController.java
+++ b/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/StudentApplicationController.java
@@ -1,0 +1,83 @@
+package com.innospace.platform.studentapplications.interfaces.rest;
+
+import com.innospace.platform.studentapplications.application.internal.services.StudentApplicationCardQueryService;
+import com.innospace.platform.studentapplications.domain.model.commands.AcceptStudentApplicationCommand;
+import com.innospace.platform.studentapplications.domain.model.commands.RejectStudentApplicationCommand;
+import com.innospace.platform.studentapplications.domain.model.queries.GetStudentApplicationByIdQuery;
+import com.innospace.platform.studentapplications.domain.model.services.StudentApplicationCommandService;
+import com.innospace.platform.studentapplications.domain.model.services.StudentApplicationQueryService;
+import com.innospace.platform.studentapplications.interfaces.rest.resources.CreateStudentApplicationResource;
+import com.innospace.platform.studentapplications.interfaces.rest.resources.StudentApplicationCardResource;
+import com.innospace.platform.studentapplications.interfaces.rest.resources.StudentApplicationResource;
+import com.innospace.platform.studentapplications.interfaces.rest.transform.CreateStudentApplicationCommandFromResourceAssembler;
+import com.innospace.platform.studentapplications.interfaces.rest.transform.StudentApplicationResourceFromEntityAssembler;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/api/v1/student-applications")
+@Tag(name = "Student Applications", description = "Endpoints for student applications to opportunities")
+public class StudentApplicationController {
+
+    private final StudentApplicationCommandService commandService;
+    private final StudentApplicationQueryService queryService;
+    private final StudentApplicationCardQueryService cardQueryService;
+
+    public StudentApplicationController(
+            StudentApplicationCommandService commandService,
+            StudentApplicationQueryService queryService,
+            StudentApplicationCardQueryService cardQueryService
+    ) {
+        this.commandService = commandService;
+        this.queryService = queryService;
+        this.cardQueryService = cardQueryService;
+    }
+
+    @PostMapping
+    public ResponseEntity<StudentApplicationResource> createApplication(@RequestBody CreateStudentApplicationResource resource) {
+        var command = CreateStudentApplicationCommandFromResourceAssembler.toCommandFromResource(resource);
+        var result = commandService.handle(command);
+
+        if (result.isEmpty()) return ResponseEntity.badRequest().build();
+
+        var created = StudentApplicationResourceFromEntityAssembler.toResourceFromEntity(result.get());
+        return ResponseEntity.created(URI.create("/api/v1/student-applications/" + created.id())).body(created);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<StudentApplicationResource> getApplicationById(@PathVariable Long id) {
+        var query = new GetStudentApplicationByIdQuery(id);
+        return queryService.handle(query)
+                .map(StudentApplicationResourceFromEntityAssembler::toResourceFromEntity)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{id}/accept")
+    public ResponseEntity<StudentApplicationResource> acceptApplication(@PathVariable Long id) {
+        var result = commandService.handle(new AcceptStudentApplicationCommand(id));
+        return result
+                .map(StudentApplicationResourceFromEntityAssembler::toResourceFromEntity)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{id}/reject")
+    public ResponseEntity<StudentApplicationResource> rejectApplication(@PathVariable Long id) {
+        var result = commandService.handle(new RejectStudentApplicationCommand(id));
+        return result
+                .map(StudentApplicationResourceFromEntityAssembler::toResourceFromEntity)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/opportunities/{opportunityId}")
+    public ResponseEntity<List<StudentApplicationCardResource>> getApplicationsByOpportunity(@PathVariable Long opportunityId) {
+        var cards = cardQueryService.getApplicationsByOpportunity(opportunityId);
+        return ResponseEntity.ok(cards);
+    }
+}

--- a/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/resources/CreateStudentApplicationResource.java
+++ b/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/resources/CreateStudentApplicationResource.java
@@ -1,0 +1,3 @@
+package com.innospace.platform.studentapplications.interfaces.rest.resources;
+
+public record CreateStudentApplicationResource(Long opportunityId, Long studentId) {}

--- a/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/resources/StudentApplicationCardResource.java
+++ b/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/resources/StudentApplicationCardResource.java
@@ -1,0 +1,12 @@
+package com.innospace.platform.studentapplications.interfaces.rest.resources;
+
+public record StudentApplicationCardResource(
+        Long id,
+        Long opportunityId,
+        String opportunityTitle,
+        String opportunityDescription,
+        Long studentId,
+        String studentName,
+        String studentPhotoUrl,
+        String managerResponse
+) {}

--- a/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/resources/StudentApplicationResource.java
+++ b/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/resources/StudentApplicationResource.java
@@ -1,0 +1,9 @@
+package com.innospace.platform.studentapplications.interfaces.rest.resources;
+
+public record StudentApplicationResource(
+        Long id,
+        Long opportunityId,
+        Long studentId,
+        String status,
+        String managerResponse
+) {}

--- a/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/transform/CreateStudentApplicationCommandFromResourceAssembler.java
+++ b/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/transform/CreateStudentApplicationCommandFromResourceAssembler.java
@@ -1,0 +1,13 @@
+package com.innospace.platform.studentapplications.interfaces.rest.transform;
+
+import com.innospace.platform.studentapplications.domain.model.commands.CreateStudentApplicationCommand;
+import com.innospace.platform.studentapplications.interfaces.rest.resources.CreateStudentApplicationResource;
+
+public class CreateStudentApplicationCommandFromResourceAssembler {
+    public static CreateStudentApplicationCommand toCommandFromResource(CreateStudentApplicationResource resource) {
+        return new CreateStudentApplicationCommand(
+                resource.opportunityId(),
+                resource.studentId()
+        );
+    }
+}

--- a/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/transform/StudentApplicationResourceFromEntityAssembler.java
+++ b/src/main/java/com/innospace/platform/studentapplications/interfaces/rest/transform/StudentApplicationResourceFromEntityAssembler.java
@@ -1,0 +1,16 @@
+package com.innospace.platform.studentapplications.interfaces.rest.transform;
+
+import com.innospace.platform.studentapplications.domain.model.aggregates.StudentApplication;
+import com.innospace.platform.studentapplications.interfaces.rest.resources.StudentApplicationResource;
+
+public class StudentApplicationResourceFromEntityAssembler {
+    public static StudentApplicationResource toResourceFromEntity(StudentApplication entity) {
+        return new StudentApplicationResource(
+                entity.getId(),
+                entity.getOpportunityId(),
+                entity.getStudentId(),
+                entity.getStatus().name(),
+                entity.getManagerResponse().name()
+        );
+    }
+}


### PR DESCRIPTION
Introduces the student applications domain model, including aggregates, commands, queries, value objects, and repository. Implements command and query services, REST controllers, and resource/assembler classes to support creating, accepting, rejecting, and retrieving student applications. Also adds endpoints for listing application cards by opportunity.